### PR TITLE
Update VS Code settings to match Foundry Book

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
   "solidity.compileUsingRemoteVersion": "v0.8.20+commit.a1b79de6",
   "solidity.packageDefaultDependenciesContractsDirectory": "src",
-  "solidity.packageDefaultDependenciesDirectory": "lib"
+  "solidity.packageDefaultDependenciesDirectory": "lib",
+  "editor.formatOnSave": true,
+  "[solidity]": {
+    "editor.defaultFormatter": "JuanBlanco.solidity"
+  },
+  "solidity.formatter": "forge"
 }


### PR DESCRIPTION
This prevents Prettier defaults from conflicting with Foundry's formatter