### PR TITLE
Only allow feeding of Aminals that exist

### DIFF
--- a/script/FeedAminal.s.sol
+++ b/script/FeedAminal.s.sol
@@ -14,7 +14,7 @@ contract FeedAminal is Script {
 
         for (uint256 i = 1; i <= 2; i++) {
             aminals.feed{value: 0.01 ether}(i);
-            
+
             console.log(
                 "Aminal love by ID by user: ",
                 aminals.getAminalLoveByIdByUser(i, 0x1f028f240A90414211425bFa38eB4917Cb32c39C)

--- a/script/SpawnAminal.s.sol
+++ b/script/SpawnAminal.s.sol
@@ -13,7 +13,6 @@ ast
 */
 
 contract SpawnAminal is Script {
-
     IAminalStructs.Visuals[] newVisuals;
 
     function run() external {
@@ -27,17 +26,15 @@ contract SpawnAminal is Script {
         // string memory uri2 = aminals.tokenURI(2);
         // console.log(uri2);
 
-        // Aminals.Visuals[] memory visuals; 
+        // Aminals.Visuals[] memory visuals;
         // // [1, 2, 1, 2, 1, 2, 1 ,2];
         // for (uint i = 1; i <= 8; i++) {
         //     visuals[i] = i % 2;
         // }
 
+        // IAminalStructs.Visuals[] memory newVisuals = new IAminalStructs.Visuals[];
 
-       // IAminalStructs.Visuals[] memory newVisuals = new IAminalStructs.Visuals[];
-
-
-        newVisuals.push(IAminalStructs.Visuals(1,2,1,2,1,2,1,2));
+        newVisuals.push(IAminalStructs.Visuals(1, 2, 1, 2, 1, 2, 1, 2));
 
         aminals.spawnInitialAminals(newVisuals);
 

--- a/src/Aminals.sol
+++ b/src/Aminals.sol
@@ -114,6 +114,7 @@ contract Aminals is IAminal, ERC721S("Aminals", "AMINALS"), AminalsDescriptor, I
         aminal.visuals.faceId = faceId;
         aminal.visuals.mouthId = mouthId;
         aminal.visuals.miscId = miscId;
+        aminal.exists = true;
         _mint(address(this), aminalId);
 
         return aminalId;
@@ -143,7 +144,12 @@ contract Aminals is IAminal, ERC721S("Aminals", "AMINALS"), AminalsDescriptor, I
     }
 
     function feed(uint256 aminalId) public payable returns (uint256) {
+        // Check if enough Ether was sent
         if (msg.value < 0.01 ether) revert NotEnoughEther();
+
+        // Check if the aminal actaually exists so people can't pre-feed aminals
+        Aminal storage animal = aminals[aminalId];
+        if (!animal.exists) revert AminalDoesNotExist();
         return _feed(aminalId, msg.sender, msg.value);
     }
 

--- a/src/IAminal.sol
+++ b/src/IAminal.sol
@@ -9,6 +9,7 @@ interface IAminal is IAminalStructs {
         external
         payable;
 
+    error AminalDoesNotExist();
     error NotEnoughEther();
     error NotSpawnable();
 }

--- a/src/IAminalStructs.sol
+++ b/src/IAminalStructs.sol
@@ -9,6 +9,7 @@ interface IAminalStructs {
         // TODO: Check whether gas usage is the same for a uint128
         uint256 energy;
         bool breeding;
+        bool exists;
         mapping(uint256 aminalTwoId => bool readyToBreed) breedableWith;
         mapping(address user => uint256 love) lovePerUser;
         Visuals visuals;

--- a/src/utils/VisualsAuction.sol
+++ b/src/utils/VisualsAuction.sol
@@ -77,8 +77,8 @@ contract VisualsAuction is IAminalStructs, Initializable, Ownable {
         console.log("Auction starting for pregnancy of ", aminalIdOne, " and ", aminalIdTwo);
 
         // Get only the Visuals struct from the mapping
-        (,,,,, visualsOne) = aminals.aminals(aminalIdOne);
-        (,,,,, visualsTwo) = aminals.aminals(aminalIdTwo);
+        (,,,,,, visualsOne) = aminals.aminals(aminalIdOne);
+        (,,,,,, visualsTwo) = aminals.aminals(aminalIdTwo);
 
         // Reset breedable variable to zero for both aminals
         aminals.disableBreedable(aminalIdOne, aminalIdTwo);

--- a/test/Aminal.t.sol
+++ b/test/Aminal.t.sol
@@ -78,8 +78,8 @@ contract AminalTest is BaseTest {
         // Get only the Visuals struct from the mapping
         Aminals.Visuals memory visualsOne;
         Aminals.Visuals memory visualsTwo;
-        (,,,,, visualsOne) = aminals.aminals(1);
-        (,,,,, visualsTwo) = aminals.aminals(2);
+        (,,,,,, visualsOne) = aminals.aminals(1);
+        (,,,,,, visualsTwo) = aminals.aminals(2);
 
         // Aminals.Visuals storage visuals = aminals.getAminalVisualsById(1);
         // uint256 love = aminals.getAminalLoveTotal(1);

--- a/test/AminalMini.t.sol
+++ b/test/AminalMini.t.sol
@@ -65,8 +65,8 @@ contract AminalMiniTest is BaseTest {
         // Get only the Visuals struct from the mapping
         Aminals.Visuals memory visualsOne;
         Aminals.Visuals memory visualsTwo;
-        (,,,,, visualsOne) = aminals.aminals(1);
-        (,,,,, visualsTwo) = aminals.aminals(2);
+        (,,,,,, visualsOne) = aminals.aminals(1);
+        (,,,,,, visualsTwo) = aminals.aminals(2);
 
         // Aminals.Visuals storage visuals = aminals.getAminalVisualsById(1);
         // uint256 love = aminals.getAminalLoveTotal(1);
@@ -82,6 +82,9 @@ contract AminalMiniTest is BaseTest {
         console.log(uint256(aminals.feed(1)));
         console.log(aminals.feed{value: 0.01 ether}(1));
         console.log(aminals.feed{value: 0.01 ether}(2));
+        // Check if aminal does not exist
+        vm.expectRevert(IAminal.AminalDoesNotExist.selector);
+        console.log(aminals.feed{value: 0.01 ether}(10));
     }
 
     function breedAminals() public {


### PR DESCRIPTION
Previously it was possible to feed aminals that don't exist yet, this could be used to game the bonding curve because you can feed aminals before they are born.

Added a test as well.